### PR TITLE
Added new operation matchers

### DIFF
--- a/lib/rspec/trailblazer.rb
+++ b/lib/rspec/trailblazer.rb
@@ -2,6 +2,9 @@ require "rspec/trailblazer/version"
 
 module RSpec
   module Trailblazer
-    autoload :Matchers, "rspec/trailblazer/matchers"
+    module Operation
+    end
+
+    Operation.autoload :Matchers, 'rspec/trailblazer/operation/matchers'
   end
 end

--- a/lib/rspec/trailblazer/extensions/hash.rb
+++ b/lib/rspec/trailblazer/extensions/hash.rb
@@ -1,0 +1,7 @@
+require 'hashie/extensions/deep_merge'
+
+module RSpec::Trailblazer
+  class Hash < ::Hash
+    include Hashie::Extensions::DeepMerge
+  end
+end

--- a/lib/rspec/trailblazer/operation/matchers.rb
+++ b/lib/rspec/trailblazer/operation/matchers.rb
@@ -1,0 +1,75 @@
+require 'rspec/trailblazer/extensions/hash'
+require 'rspec/trailblazer/support/operation'
+
+module RSpec::Trailblazer::Operation
+  module Matchers
+    extend ::RSpec::Matchers::DSL
+    include ::Support::Operation
+
+    matcher :be_successful do
+      match do |operation|
+        result = _call(operation, _run_params)
+
+        block_arg.call(result) if block_arg && result.success?
+        result.success?
+      end
+
+      chain :with, :_run_params
+
+      failure_message do |operation|
+        "expected #{operation} to be successful"
+      end
+    end
+
+
+    matcher :be_failure do
+      match do |operation|
+        result = _call(operation, _run_params)
+
+        block_arg.call(result) if block_arg && result.failure?
+        result.failure?
+      end
+
+      chain :with, :_run_params
+
+      failure_message do |operation|
+        "expected #{operation} to be failure"
+      end
+    end
+
+
+    matcher :have_properties do |args|
+      match do |operation|
+        @_result = _call(operation, @_run_params)
+        return false unless @_result[:model]
+
+        expect(@_result[:model]).have_attributes(args)
+      end
+
+      chain :with, :_run_params
+
+      failure_message do |operation|
+        "expected #{operation} to have model" unless @_result[:model]
+      end
+    end
+
+
+    matcher :have_invalid_properties do |*args|
+      match do |operation|
+        @_form = _form_for(operation, _run_params)
+        return false unless @_form
+
+        @_valid_properties = args.map(&:to_s) - @_form.errors.keys.map(&:to_s)
+        @_valid_properties.blank?
+      end
+
+      chain :with, :_run_params
+
+      failure_message do |operation|
+        return "expected that #{operation} to build form" unless @_form
+
+        "expected #{operation} to have invalid #{@_valid_properties.join(', ')}"
+      end
+    end
+  end
+end

--- a/lib/rspec/trailblazer/support/operation.rb
+++ b/lib/rspec/trailblazer/support/operation.rb
@@ -1,0 +1,14 @@
+module Support
+  module Operation
+    def _call(operation, args)
+      params = defined?(default_params) ?
+        RSpec::Trailblazer::Hash[default_params].deep_merge(args || {}) : args
+
+      operation.call(params)
+    end
+
+    def _form_for(operation, args)
+      _call(operation, args)['contract.default']
+    end
+  end
+end


### PR DESCRIPTION
- Removed existing helpers `use_model` and `present_model` matchers (So not backward compatible).
- Added few new matchers like `be_success`, `be_failure`, `have_properties` and `have_invalid_properties` :beers: 
- Added ability to define default values to be passed to an operation using `default_params` and ability to override them using `with` helper.